### PR TITLE
Remove final '/' from package_dir={'': 'src/python/'},

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     author='Jack Zhu, John Miller, Paul Quigley',
     author_email='jackzhu@stanford.edu, millerjp@stanford.edu, piq93@stanford.edu',
     ext_modules=[canon],
-    package_dir={'': 'src/python/'},
+    package_dir={'': 'src/python'},
     py_modules=['canonInterface', 'CVXcanon'],
     description='A low-level library to perform the matrix building step in cvxpy, a convex optimization modeling software.',
     license='GPLv3',


### PR DESCRIPTION
The final '/' causes the installation to fail under Windows:

```
    C:\Python34\>pip install cvxcanonCollecting cvxcanon  Using cached CVXcanon-0.0.17.tar.gz    Complete output from command python setup.py egg_info:    running egg_info    creating pip-egg-info\CVXcanon.egg-info    writing top-level names to pip-egg-info\CVXcanon.egg-info\top_level.txt    writing dependency_links to pip-egg-info\CVXcanon.egg-info\dependency_links.txt    writing requirements to pip-egg-info\CVXcanon.egg-info\requires.txt    writing pip-egg-info\CVXcanon.egg-info\PKG-INFO    writing manifest file 'pip-egg-info\CVXcanon.egg-info\SOURCES.txt'    warning: manifest_maker: standard file '-c' not found
        Traceback (most recent call last):      File "<string>", line 20, in <module>      File "C:\Users\Seth\AppData\Local\Temp\pip-build-juhpwjno\cvxcanon\setup.py", line 61, in <module>        setup_requires=['numpy']      File "c:\python34\lib\distutils\core.py", line 148, in setup        dist.run_commands()      File "c:\python34\lib\distutils\dist.py", line 955, in run_commands        self.run_command(cmd)      File "c:\python34\lib\distutils\dist.py", line 974, in run_command        cmd_obj.run()      File "<string>", line 15, in replacement_run      File "c:\python34\lib\site-packages\setuptools\command\egg_info.py", line 207, in find_sources        mm.run()      File "c:\python34\lib\site-packages\setuptools\command\egg_info.py", line 291, in run        self.add_defaults()      File "c:\python34\lib\site-packages\setuptools\command\egg_info.py", line 320, in add_defaults        sdist.add_defaults(self)      File "c:\python34\lib\site-packages\setuptools\command\sdist.py", line 118, in add_defaults        build_py = self.get_finalized_command('build_py')      File "c:\python34\lib\distutils\cmd.py", line 299, in get_finalized_command        cmd_obj.ensure_finalized()      File "c:\python34\lib\distutils\cmd.py", line 107, in ensure_finalized        self.finalize_options()      File "c:\python34\lib\site-packages\setuptools\command\build_py.py", line 28, in finalize_options        orig.build_py.finalize_options(self)      File "c:\python34\lib\distutils\command\build_py.py", line 55, in finalize_options        self.package_dir[name] = convert_path(path)      File "c:\python34\lib\distutils\util.py", line 127, in convert_path        raise ValueError("path '%s' cannot end with '/'" % pathname)    ValueError: path 'src/python/' cannot end with '/'
        ----------------------------------------Command "python setup.py egg_info" failed with error code 1 in C:\Users\Seth\AppData\Local\Temp\pip-build-juhpwjno\cvxcanon
```
