### PR TITLE
Postpone importing numpy until compiling starts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,4 @@
-from setuptools import setup, Extension, find_packages
-from setuptools.command.install import install
-from distutils.command.build import build
-import os
+from setuptools import setup, Extension
 
 
 class get_numpy_include(object):
@@ -18,10 +15,6 @@ canon = Extension(
     include_dirs=['src/', 'src/python/', 'include/Eigen', get_numpy_include()]
 )
 
-base_dir = os.path.dirname(__file__)
-about = {}
-with open(os.path.join(base_dir, "src", "python", "_version__.py")) as f:
-    exec(f.read(), about)
 
 setup(
     name='CVXcanon',

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,21 @@
 from setuptools import setup, Extension, find_packages
 from setuptools.command.install import install
 from distutils.command.build import build
-import numpy
 import os
+
+
+class get_numpy_include(object):
+    """Returns Numpy's include path with lazy import.
+    """
+    def __str__(self):
+        import numpy
+        return numpy.get_include()
+
 
 canon = Extension(
     '_CVXcanon',
     sources=['src/CVXcanon.cpp', 'src/LinOpOperations.cpp', 'src/python/CVXcanon_wrap.cpp'],
-    include_dirs=['src/', 'src/python/', 'include/Eigen', numpy.get_include()]
+    include_dirs=['src/', 'src/python/', 'include/Eigen', get_numpy_include()]
 )
 
 base_dir = os.path.dirname(__file__)


### PR DESCRIPTION
This lazy evaluation enables CVXcanon to be pip installed even if numpy isn't
separately installed beforehand, because pip is able to interpret the
requirements from setup.py. Previously, since the setup file for CVXcanon began
by importing numpy, pip would error if numpy wasn't already installed.

For example, suppose your requirements.txt is like

```
numpy>=1.12.0             
scipy>=0.18.1             
CVXcanon>=0.1.1
```

and run `pip install -r requirements.txt` to install those packages,
pip checks dependencies written in install_requires in setup.py in order to
install those dependencies before compiling CVXcanon starts.
However, since setup.py imports numpy at the top, this checking step fails due
to an import error.

This pull request introduces a lazy import of numpy to postpone importing
it until actual compiling phase starts, and it allows pip to evaluate setup.py
and install dependencies first.

After numpy and scipy are installed, the compiling CVXcanon phase starts.
pip now evaluates the lazy import to obtain the include path of numpy.
At the time, since numpy has been installed, no import error raises.

You will also no longer need `pip install numpy` as a first step in the CVXcanon
installation instructions, if missing it will be installed when CVXcanon is pip
installed.
