### PR TITLE
include LICENSE in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ graft src
 graft include/Eigen
 graft tests
 graft src/python
+include LICENSE


### PR DESCRIPTION
Right now the `setup.py sdist` files don't include `LICENSE`; this makes them do so.